### PR TITLE
Implemented Improvement: better transitions between screens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The app should always be launchable and working in the *main* branch, but this i
 		- [ ]	Add Reviews section
 		- [x] 	Add more Extra Details: budget, profit, languages. :heavy_check_mark: (2023.01.31)
 - [ ] Adapt for different screen sizes. 
-- [ ] Better and more appropriate transitions between screens
+- [x] Better and more appropriate transitions between screens. :heavy_check_mark: (2023.02.08)
 - [ ] Caching of Search and Trending data and getting that data via flows.
 - [ ] Possible theme change.
 


### PR DESCRIPTION
MainActivity: added two functions for getting an Exit and Enter transition. Changed the logic of determining the TopBar title and now hiding the top bar with AnimatedVisibility. Moved out determining the top bar title for TitleListScreen to it's own Composable and Viewmodel.

TitleListScreen.kt: hiding the FilterSection drawer when it's closed so it's not seen during horizontal screen transitions.

TitleListViewModel.kt: introduced _screenTitle stateflow and changes previous filterState and titleListState to have a private mutable stateflow and public immutable one.