### PR TITLE
Fixed a bug where genres and apiConfiguration would only be downloaded from api if WatchlistScreen was opened. 

### DIFF
--- a/app/src/main/java/com/myapplications/mywatchlist/core/di/AbstractionsModule.kt
+++ b/app/src/main/java/com/myapplications/mywatchlist/core/di/AbstractionsModule.kt
@@ -1,5 +1,7 @@
 package com.myapplications.mywatchlist.core.di
 
+import com.myapplications.mywatchlist.core.util.NetworkMonitor
+import com.myapplications.mywatchlist.core.util.NetworkMonitorImpl
 import com.myapplications.mywatchlist.core.util.NetworkStatusManager
 import com.myapplications.mywatchlist.core.util.NetworkStatusManagerImpl
 import com.myapplications.mywatchlist.data.datastore.UserPrefsRepository
@@ -68,4 +70,7 @@ abstract class AbstractionsModule {
 
     @Binds
     abstract fun bindTitlesRemoteMediatorProvider(titlesRemoteMediatorProviderImpl: TitlesRemoteMediatorProviderImpl): TitlesRemoteMediatorProvider
+
+    @Binds
+    abstract fun bindNetworkMonitor(networkMonitorImpl: NetworkMonitorImpl): NetworkMonitor
 }

--- a/app/src/main/java/com/myapplications/mywatchlist/core/util/NetworkMonitor.kt
+++ b/app/src/main/java/com/myapplications/mywatchlist/core/util/NetworkMonitor.kt
@@ -1,0 +1,71 @@
+package com.myapplications.mywatchlist.core.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.core.content.getSystemService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import javax.inject.Inject
+
+interface NetworkMonitor {
+    val isOnline: Flow<Boolean>
+}
+
+class NetworkMonitorImpl @Inject constructor(
+    @ApplicationContext val context: Context
+) : NetworkMonitor {
+
+    override val isOnline: Flow<Boolean> = callbackFlow {
+        val connectivityManager = context.getSystemService<ConnectivityManager>()
+
+        /**
+         * The callback's methods are invoked on changes to *any* network, not just the active
+         * network. So to check for network connectivity, one must query the active network of the
+         * ConnectivityManager.
+         */
+        val callback = object : NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                channel.trySend(connectivityManager.isCurrentlyConnected())
+            }
+
+            override fun onLost(network: Network) {
+                channel.trySend(connectivityManager.isCurrentlyConnected())
+            }
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities
+            ) {
+                channel.trySend(connectivityManager.isCurrentlyConnected())
+            }
+        }
+
+        connectivityManager?.registerNetworkCallback(
+            NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build(),
+            callback
+        )
+
+        channel.trySend(connectivityManager.isCurrentlyConnected())
+
+        awaitClose {
+            connectivityManager?.unregisterNetworkCallback(callback)
+        }
+    }.conflate()
+
+    private fun ConnectivityManager?.isCurrentlyConnected() = when (this) {
+        null -> false
+        else -> activeNetwork
+            ?.let(::getNetworkCapabilities)
+            ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            ?: false
+    }
+}

--- a/app/src/main/java/com/myapplications/mywatchlist/ui/WatchlistAppStartup.kt
+++ b/app/src/main/java/com/myapplications/mywatchlist/ui/WatchlistAppStartup.kt
@@ -1,0 +1,57 @@
+package com.myapplications.mywatchlist.ui
+
+import androidx.work.*
+import com.myapplications.mywatchlist.core.util.Constants
+import com.myapplications.mywatchlist.core.workmanager.UpdateConfigurationInfoWorker
+import com.myapplications.mywatchlist.data.ApiGetGenresExceptions
+import com.myapplications.mywatchlist.domain.repositories.GenresRepository
+import com.myapplications.mywatchlist.domain.result.BasicResult
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+private const val TAG = "APP_STARTUP"
+
+class WatchlistAppStartup @Inject constructor(
+    private val genresRepository: GenresRepository,
+    private val workManager: WorkManager
+) {
+
+    /**
+     * Initializes an update of list of Genres from the TMDB Api which are needed to be able to map
+     * genre ids received from the same api on every fetch of information about titles.
+     */
+    suspend fun updateGenres(): BasicResult {
+        return when (val result = genresRepository.updateGenresFromApi()) {
+            is BasicResult.Failure -> {
+                if (result.exception is ApiGetGenresExceptions.NoConnectionException) {
+                    BasicResult.Failure(exception = result.exception)
+                } else {
+                    BasicResult.Failure(exception = null)
+                }
+            }
+            is BasicResult.Success -> BasicResult.Success(null)
+        }
+    }
+
+    /**
+     * Creates a periodic [WorkRequest] that updated the Configuration details from the api. If this
+     * work had already been scheduled, then the ExistingPeriodicWorkPolicy.KEEP will ensure the
+     * existing work request is kept and not replaced.
+     */
+    fun launchPeriodicConfigurationUpdateWorker() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+        val workRequest =
+            PeriodicWorkRequestBuilder<UpdateConfigurationInfoWorker>(3, TimeUnit.DAYS)
+                .setConstraints(constraints)
+                .addTag("UPDATE_CONFIGURATION")
+                .build()
+        workManager.enqueueUniquePeriodicWork(
+            /* uniqueWorkName = */ Constants.PERIODIC_WORK_REQUEST_UPDATE_CONFIGURATION,
+            /* existingPeriodicWorkPolicy = */ ExistingPeriodicWorkPolicy.KEEP,
+            /* periodicWork = */ workRequest
+        )
+    }
+
+}

--- a/app/src/main/java/com/myapplications/mywatchlist/ui/watchlist/WatchlistScreen.kt
+++ b/app/src/main/java/com/myapplications/mywatchlist/ui/watchlist/WatchlistScreen.kt
@@ -25,7 +25,6 @@ import com.myapplications.mywatchlist.ui.components.TitleItemsList
 fun WatchlistScreen(
     placeholderImage: Painter,
     onTitleClicked: (TitleItemFull) -> Unit,
-    onShowSnackbar: (String) -> Unit,
     modifier: Modifier
 ) {
 
@@ -35,16 +34,6 @@ fun WatchlistScreen(
     val isLoading = uiState.value.isLoading
     val isNoData = uiState.value.isNoData
     val isTitlesAvailable = !uiState.value.titleItemsFull.isNullOrEmpty()
-    val showSnackbar = uiState.value.showSnackbar
-
-    if (showSnackbar != null) {
-        when (showSnackbar) {
-            WatchlistSnackbarType.NO_INTERNET -> {
-                onShowSnackbar(stringResource(id = R.string.watchlist_snackbar_not_connected))
-                viewModel.resetSnackbarType()
-            }
-        }
-    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/myapplications/mywatchlist/ui/watchlist/WatchlistUiState.kt
+++ b/app/src/main/java/com/myapplications/mywatchlist/ui/watchlist/WatchlistUiState.kt
@@ -7,10 +7,5 @@ data class WatchlistUiState(
     val titleItemsFull: List<TitleItemFull>? = null,
     val isLoading: Boolean = true,
     val isNoData: Boolean = false,
-    val filter: TitleTypeFilter = TitleTypeFilter.All,
-    val showSnackbar: WatchlistSnackbarType? = null
+    val filter: TitleTypeFilter = TitleTypeFilter.All
 )
-
-enum class WatchlistSnackbarType{
-    NO_INTERNET
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
 
     <!-- GENERAL ERRORS -->
     <string name="error_no_internet_connection">Please check if you are connected to the internet</string>
+    <string name="error_no_internet_connection_snackbar">⚠️ You are not connected to the internet</string>
     <string name="error_something_went_wrong">Oops…Something went wrong</string>
 
     <!-- GENERAL BUTTON LABELS -->


### PR DESCRIPTION
Lifted out functionality of getting the initial genres list and the configuration file from the api out of WatchlistViewModel.kt and created a separate WatchlistAppStartup.kt that handles these actions.

Created a NetworkMonitor.kt (used example from Now in Android app) that monitors the connectivity. Added a LaunchedEffect to MainActivity that shows a "You are offline" snackbar when offline and launches (if not already done) the methods in WatchlistAppStartup.kt that update genres and api configuration.